### PR TITLE
Revised this endpoint to be able to search by status alone

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -359,6 +359,12 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: "KEYS_ONLY"
+        - IndexName: "StatusIndex"
+          KeySchema:
+            - AttributeName: "status"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "KEYS_ONLY"
 
   PatientsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
# Description

Created and deployed a 2nd GSI for the prescriptions table to allow search by status alone. Updated the PrescriptionDao to work with the case of a query "none+'status'"